### PR TITLE
Helper to read embedded json paths

### DIFF
--- a/jsonslice.go
+++ b/jsonslice.go
@@ -118,6 +118,50 @@ func getEmptyNode() *tNode {
 	return nod
 }
 
+// GetEmbeddedPaths parses path and returns each distinct root-based JSONPath ($...)
+// referenced inside a [?( ... )] filter, in first-seen order. It does not read JSON.
+func GetEmbeddedPaths(path string) []string {
+	if len(path) == 0 {
+		return nil
+	}
+	if len(path) == 1 && path[0] == '$' {
+		return nil
+	}
+	if path[0] != '$' {
+		return nil
+	}
+
+	node, _, err := readRef(unspace([]byte(path)), 1, 0)
+	if err != nil {
+		repool(node)
+		return nil
+	}
+
+	paths := map[string]struct{}{}
+	n := node
+	for {
+		if n == nil {
+			break
+		}
+		if n.Filter != nil {
+			for _, tok := range n.Filter {
+				if tok.Type == xpression.VariableOperand && tok.Operand.Str[0] == '$' {
+					paths[string(tok.Operand.Str)] = struct{}{}
+				}
+			}
+		}
+		n = n.Next
+	}
+
+	repool(node)
+
+	out := make([]string, 0, len(paths))
+	for p := range paths {
+		out = append(out, p)
+	}
+	return out
+}
+
 // Get returns a part of input, matching jsonpath.
 // In terms of allocations there are two cases of retreiving data from the input:
 //  1. simple case: the result is a simple subslice of a source input.

--- a/jsonslice_unit_test.go
+++ b/jsonslice_unit_test.go
@@ -4,6 +4,146 @@ import (
 	"testing"
 )
 
+// TestGetEmbeddedPaths covers $-root paths referenced inside [?( )] filters only (not {{ }} templates
+// or $.x used as an array index). Paths use generic names (foo, bar, a, b, …) but match real shapes.
+func TestGetEmbeddedPaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		wantNil   bool
+		wantPaths []string // order ignored; empty means expect non-nil slice with len 0 when wantNil is false
+	}{
+		{
+			name:    "empty path",
+			path:    "",
+			wantNil: true,
+		},
+		{
+			name:    "only root",
+			path:    "$",
+			wantNil: true,
+		},
+		{
+			name:    "does not start with dollar",
+			path:    "foo",
+			wantNil: true,
+		},
+		{
+			name:    "malformed root subscript",
+			path:    "$.[",
+			wantNil: true,
+		},
+		{
+			name:    "go template index brackets not filter embeds",
+			path:    `$.foo[{{$.bar}}]`,
+			wantNil: true,
+		},
+		{
+			name:    "dollar in array index bracket not filter variable",
+			path:    `$.foo.bar[$.baz.qux].name`,
+			wantNil: true,
+		},
+		{
+			name:      "property path no filter",
+			path:      "$.foo.bar",
+			wantPaths: []string{},
+		},
+		{
+			name:      "filter with only at references",
+			path:      `$.foo[?(@.a==1)]`,
+			wantPaths: []string{},
+		},
+		{
+			name:      "filter embeds dollar path after property compare",
+			path:      `$.foo.bar.baz[?(@.k==$.a.b.c)].d`,
+			wantPaths: []string{"$.a.b.c"},
+		},
+		{
+			name:      "same embed one fewer outer segment",
+			path:      `$.foo.bar[?(@.k==$.a.b.c)].d`,
+			wantPaths: []string{"$.a.b.c"},
+		},
+		{
+			name:      "spaces around equality before embedded path",
+			path:      `$.foo.bar[?(@.x == $.a.b)].c`,
+			wantPaths: []string{"$.a.b"},
+		},
+		{
+			name:      "spaces around equality different left property",
+			path:      `$.foo.bar[?(@.y == $.c.d)]`,
+			wantPaths: []string{"$.c.d"},
+		},
+		{
+			name:      "filter embeds path used as inner dependency",
+			path:      `$.foo.items[?(@.id==$.bar.baz)].name`,
+			wantPaths: []string{"$.bar.baz"},
+		},
+		{
+			name:      "two filters in sequence each embed dollar path",
+			path:      `$.a[?(@.x==$.b)].c[?(@.y==$.d)]`,
+			wantPaths: []string{"$.b", "$.d"},
+		},
+		{
+			name:      "filter embeds indexed dollar path",
+			path:      `$.foo.items[?(@.code != $.bar[0].code)].value`,
+			wantPaths: []string{"$.bar[0].code"},
+		},
+		{
+			name:      "same indexed embed longer outer path",
+			path:      `$.baz.qux.items[?(@.code != $.bar[0].code)].value`,
+			wantPaths: []string{"$.bar[0].code"},
+		},
+		{
+			name:      "two distinct dollar paths in one filter",
+			path:      `$.foo[?(@.a==$.b && @.c==$.d)]`,
+			wantPaths: []string{"$.b", "$.d"},
+		},
+		{
+			name:      "repeated dollar path deduplicated",
+			path:      `$.foo[?(@.a==$.b.c && @.a==$.b.c)]`,
+			wantPaths: []string{"$.b.c"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetEmbeddedPaths(tc.path)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("GetEmbeddedPaths(%q) = %v, want nil", tc.path, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("GetEmbeddedPaths(%q) = nil, want non-nil slice", tc.path)
+			}
+			if len(tc.wantPaths) == 0 {
+				if len(got) != 0 {
+					t.Fatalf("GetEmbeddedPaths(%q) = %v, want empty slice", tc.path, got)
+				}
+				return
+			}
+			if len(got) != len(tc.wantPaths) {
+				t.Fatalf("GetEmbeddedPaths(%q) = %v (len %d), want len %d %v", tc.path, got, len(got), len(tc.wantPaths), tc.wantPaths)
+			}
+			used := make([]bool, len(got))
+			for _, w := range tc.wantPaths {
+				found := false
+				for i := range got {
+					if !used[i] && got[i] == w {
+						used[i] = true
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("GetEmbeddedPaths(%q) = %v, missing or extra mismatch for want %q (want %v)", tc.path, got, w, tc.wantPaths)
+				}
+			}
+		})
+	}
+}
+
 func Test_AdjustBounds(t *testing.T) {
 	type Input struct{ left, right, step int }
 	type Expected struct {


### PR DESCRIPTION
The workflow state machine used a regex to find embedded JSONPath references inside expressions. Regex is brittle and can miss or mis-handle valid paths, so registration/resolution of dependencies could be inconsistent with how paths are actually parsed.

**Change**
Add jsonslice.GetEmbeddedPaths, which parses the path the same way as [jsonslice.Get](https://github.com/sailpoint-oss/jsonslice/blob/1091467abd7d970ec61f14b4f1c3d25e9c2bc5af/jsonslice.go#L125) and returns the distinct root-based $… paths referenced inside `[?( … )]` filters. The lib now uses this API instead of relying on regex for that discovery.

**Why this is correct**
Embedded path detection is aligned with the real JSONPath grammar/parser in `jsonslice`, so behavior stays consistent with evaluation rules and drops the regex dependency for this case.