### PR TITLE
PLTWRKFLW-13154: Fetch filter paths from JSON paths

### DIFF
--- a/jsonslice.go
+++ b/jsonslice.go
@@ -119,7 +119,7 @@ func getEmptyNode() *tNode {
 }
 
 // GetEmbeddedPaths parses path and returns each distinct root-based JSONPath ($...)
-// referenced inside a [?( ... )] filter, in first-seen order. It does not read JSON.
+// referenced inside a [?( ... )] filter, in first-seen order.
 func GetEmbeddedPaths(path string) []string {
 	if len(path) == 0 {
 		return nil
@@ -159,6 +159,51 @@ func GetEmbeddedPaths(path string) []string {
 	for p := range paths {
 		out = append(out, p)
 	}
+	return out
+}
+
+// GetFilterRelativePaths parses path and returns each distinct relative JSONPath (@...)
+// referenced inside a [?( ... )] filter, in first-seen order.
+func GetFilterRelativePaths(path string) []string {
+	if len(path) == 0 {
+		return nil
+	}
+	if len(path) == 1 && path[0] == '$' {
+		return nil
+	}
+	if path[0] != '$' {
+		return nil
+	}
+
+	node, _, err := readRef(unspace([]byte(path)), 1, 0)
+	if err != nil {
+		repool(node)
+		return nil
+	}
+
+	seen := map[string]struct{}{}
+	out := make([]string, 0)
+	n := node
+	for {
+		if n == nil {
+			break
+		}
+		if n.Filter != nil {
+			for _, tok := range n.Filter {
+				if tok.Type == xpression.VariableOperand && len(tok.Operand.Str) > 0 && tok.Operand.Str[0] == '@' {
+					s := string(tok.Operand.Str)
+					if _, ok := seen[s]; !ok {
+						seen[s] = struct{}{}
+						out = append(out, s)
+					}
+				}
+			}
+		}
+		n = n.Next
+	}
+
+	repool(node)
+
 	return out
 }
 

--- a/jsonslice_unit_test.go
+++ b/jsonslice_unit_test.go
@@ -144,6 +144,123 @@ func TestGetEmbeddedPaths(t *testing.T) {
 	}
 }
 
+// TestGetFilterRelativePaths covers @-relative paths referenced inside [?( )] filters only.
+// It mirrors TestGetEmbeddedPaths but asserts on the current-element ("@") operands instead of
+// the root ("$") operands. Order is significant: paths are returned in first-seen order with
+// duplicates removed.
+func TestGetFilterRelativePaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		wantNil   bool
+		wantPaths []string // order significant; empty means expect non-nil slice with len 0 when wantNil is false
+	}{
+		{
+			name:    "empty path",
+			path:    "",
+			wantNil: true,
+		},
+		{
+			name:    "only root",
+			path:    "$",
+			wantNil: true,
+		},
+		{
+			name:    "does not start with dollar",
+			path:    "foo",
+			wantNil: true,
+		},
+		{
+			name:    "malformed root subscript",
+			path:    "$.[",
+			wantNil: true,
+		},
+		{
+			name:    "go template index brackets are a parse error",
+			path:    `$.foo[{{$.bar}}]`,
+			wantNil: true,
+		},
+		{
+			name:      "property path no filter",
+			path:      "$.foo.bar",
+			wantPaths: []string{},
+		},
+		{
+			name:      "filter with single at reference",
+			path:      `$.foo[?(@.a==1)]`,
+			wantPaths: []string{"@.a"},
+		},
+		{
+			name:      "filter compares at reference to dollar path",
+			path:      `$.foo.bar.baz[?(@.k==$.a.b.c)].d`,
+			wantPaths: []string{"@.k"},
+		},
+		{
+			name:      "two at references in one filter preserve order",
+			path:      `$.foo[?(@.a==$.b && @.c==$.d)]`,
+			wantPaths: []string{"@.a", "@.c"},
+		},
+		{
+			name:      "two at references compared to literals",
+			path:      `$.foo[?(@.a==1 && @.b==2)]`,
+			wantPaths: []string{"@.a", "@.b"},
+		},
+		{
+			name:      "two filters in sequence each contribute one at reference",
+			path:      `$.a[?(@.x==1)].c[?(@.y==2)]`,
+			wantPaths: []string{"@.x", "@.y"},
+		},
+		{
+			name:      "repeated at reference deduplicated",
+			path:      `$.foo[?(@.a==1 && @.a==2)]`,
+			wantPaths: []string{"@.a"},
+		},
+		{
+			name:      "quoted at reference key",
+			path:      `$.items[?(@['first name']=="x")]`,
+			wantPaths: []string{"@['first name']"},
+		},
+		{
+			name:      "indexed at reference",
+			path:      `$.foo[?(@.a[0].b==1)]`,
+			wantPaths: []string{"@.a[0].b"},
+		},
+		{
+			name:      "bare at reference",
+			path:      `$.foo[?(@==1)]`,
+			wantPaths: []string{"@"},
+		},
+		{
+			name:      "filter with only dollar reference has no relatives",
+			path:      `$.foo[?($.a.b==1)]`,
+			wantPaths: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetFilterRelativePaths(tc.path)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("GetFilterRelativePaths(%q) = %v, want nil", tc.path, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("GetFilterRelativePaths(%q) = nil, want non-nil slice", tc.path)
+			}
+			if len(got) != len(tc.wantPaths) {
+				t.Fatalf("GetFilterRelativePaths(%q) = %v (len %d), want %v (len %d)", tc.path, got, len(got), tc.wantPaths, len(tc.wantPaths))
+			}
+			for i := range tc.wantPaths {
+				if got[i] != tc.wantPaths[i] {
+					t.Fatalf("GetFilterRelativePaths(%q) = %v, want %v (mismatch at index %d)", tc.path, got, tc.wantPaths, i)
+				}
+			}
+		})
+	}
+}
+
 func Test_AdjustBounds(t *testing.T) {
 	type Input struct{ left, right, step int }
 	type Expected struct {


### PR DESCRIPTION
- Adds `GetFilterRelativePaths`, a parsing helper that extracts the relative (`@...`) paths referenced inside JSONPath filter expressions ([?( ... )]). This lays the groundwork for output trimming — a later change will use these paths to determine which fields a filter condition reads, so they can be preserved when trimming output.

- This PR is intentionally scoped to parsing only; it introduces the helper and locks its behavior with tests.